### PR TITLE
fix(maida): track active gamepad index via connect events

### DIFF
--- a/src/hooks/useGameInput.js
+++ b/src/hooks/useGameInput.js
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { vibrate, vibrateProgress } from '../services/haptics';
+import { getActiveGamepad } from '../services/gamepad';
 import { discretizeStick } from './gamepadLogic';
 
 /**
@@ -297,8 +298,10 @@ export function useGameInput({
         const pollGamepad = () => {
             if (!isPolling || !document.hasFocus()) return; // Stop if window lost focus
 
-            const gamepads = navigator.getGamepads?.() || [];
-            const gp = gamepads[0];
+            // Active gamepad index is tracked in services/gamepad.js, which
+            // listens for gamepadconnected/gamepaddisconnected so a pad that
+            // reconnects to a new slot (common on Windows HID) is still read.
+            const gp = getActiveGamepad();
 
             if (gp) {
                 const btn = (i) => gp.buttons[i]?.pressed;

--- a/src/hooks/useGamepadScroll.js
+++ b/src/hooks/useGamepadScroll.js
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { resolveScrollTarget } from '../utils/scroll';
+import { getActiveGamepad } from '../services/gamepad';
 import {
     computeScrollDelta,
     shouldSuppressRStickScroll
@@ -54,8 +55,7 @@ export function useGamepadScroll({ disabled = false } = {}) {
             const dtSec = lastFrameTs === 0 ? 0 : (now - lastFrameTs) / 1000;
             lastFrameTs = now;
 
-            const pads = navigator.getGamepads?.() || [];
-            const gp = pads[0];
+            const gp = getActiveGamepad();
             if (gp && gp.axes && gp.axes.length > R_STICK_Y && dtSec > 0) {
                 const axisX = gp.axes[R_STICK_X] ?? 0;
                 const axisY = gp.axes[R_STICK_Y] ?? 0;

--- a/src/services/gamepad.js
+++ b/src/services/gamepad.js
@@ -1,0 +1,115 @@
+/**
+ * Gamepad connection tracker.
+ *
+ * Centralizes "which gamepad index is currently active" so input polling
+ * (useGameInput), analog scroll (useGamepadScroll) and haptics all read
+ * the same pad. On Windows HID a disconnect does not always fire a clean
+ * `gamepaddisconnected` event, so the browser can reassign a reconnected
+ * pad to index 1 while a ghost stays at index 0; hardcoding `[0]` then
+ * stops detecting input until the page reloads.
+ *
+ * This module:
+ *  - Listens for `gamepadconnected` / `gamepaddisconnected` on window
+ *  - Tracks the first non-null pad's index
+ *  - Re-scans on disconnect so we fall back to any remaining pad
+ *  - Exposes `getActiveGamepad()` which returns the live Gamepad object
+ *    (or null). Callers pass no index, which keeps them in sync.
+ *
+ * Initialization is idempotent and lazy: the first call to
+ * `getActiveGamepad()` installs listeners and runs an initial scan.
+ * This handles the "app launched with gamepad already connected"
+ * case where the `gamepadconnected` event fired before we mounted.
+ */
+
+let activeIndex = null;
+let initialized = false;
+
+function rescan() {
+    if (typeof navigator === 'undefined' || typeof navigator.getGamepads !== 'function') {
+        activeIndex = null;
+        return;
+    }
+    const pads = navigator.getGamepads() || [];
+    for (let i = 0; i < pads.length; i++) {
+        if (pads[i]) {
+            activeIndex = i;
+            return;
+        }
+    }
+    activeIndex = null;
+}
+
+function handleConnected(event) {
+    // Prefer the freshly-connected pad; this matches user intent when a
+    // second controller is plugged in mid-session.
+    if (event?.gamepad && typeof event.gamepad.index === 'number') {
+        activeIndex = event.gamepad.index;
+    } else {
+        rescan();
+    }
+}
+
+function handleDisconnected(event) {
+    const idx = event?.gamepad?.index;
+    if (idx !== undefined && idx === activeIndex) {
+        activeIndex = null;
+    }
+    // Always rescan — if another pad is still present, fall back to it.
+    rescan();
+}
+
+function ensureInitialized() {
+    if (initialized) return;
+    initialized = true;
+    if (typeof window === 'undefined') return;
+    window.addEventListener('gamepadconnected', handleConnected);
+    window.addEventListener('gamepaddisconnected', handleDisconnected);
+    // Initial scan for pads already connected before listeners installed.
+    rescan();
+}
+
+/**
+ * Returns the currently active Gamepad object or null.
+ *
+ * IMPORTANT: Gamepad objects from `navigator.getGamepads()` are snapshots
+ * in Chromium — you must call this every frame to see updated button /
+ * axis state. Do not cache the returned object across frames.
+ */
+export function getActiveGamepad() {
+    ensureInitialized();
+    if (activeIndex === null) return null;
+    if (typeof navigator === 'undefined' || typeof navigator.getGamepads !== 'function') {
+        return null;
+    }
+    const pads = navigator.getGamepads() || [];
+    const gp = pads[activeIndex];
+    if (!gp) {
+        // Ghost entry: the browser kept the slot but the pad is gone.
+        // Rescan for another live pad, then return whatever is active.
+        rescan();
+        if (activeIndex === null) return null;
+        return navigator.getGamepads()?.[activeIndex] ?? null;
+    }
+    return gp;
+}
+
+/**
+ * Returns the currently active gamepad index or null. Exposed mainly
+ * for tests and diagnostics; most callers should use `getActiveGamepad()`.
+ */
+export function getActiveGamepadIndex() {
+    ensureInitialized();
+    return activeIndex;
+}
+
+/**
+ * Test-only: reset module state. Production code must not call this.
+ */
+export function __resetForTests() {
+    if (typeof window !== 'undefined' && initialized) {
+        window.removeEventListener('gamepadconnected', handleConnected);
+        window.removeEventListener('gamepaddisconnected', handleDisconnected);
+    }
+    activeIndex = null;
+    initialized = false;
+}

--- a/src/services/haptics.js
+++ b/src/services/haptics.js
@@ -3,6 +3,7 @@
  * Silent no-op if gamepad not connected or API not supported.
  * Intensity configurable via localStorage (0-100, default 100).
  */
+import { getActiveGamepad } from './gamepad';
 
 const STORAGE_KEY = 'maida_haptic_intensity';
 const DEFAULT_INTENSITY = 100;
@@ -40,7 +41,7 @@ export function vibrate(type = 'light') {
     const intensity = getIntensity();
     if (intensity === 0) return;
 
-    const gp = navigator.getGamepads?.()?.[0];
+    const gp = getActiveGamepad();
     if (!gp?.vibrationActuator) return;
 
     const preset = PRESETS[type] || PRESETS.light;
@@ -59,7 +60,7 @@ export function vibrateProgress(progress) {
     const intensity = getIntensity();
     if (intensity === 0) return;
 
-    const gp = navigator.getGamepads?.()?.[0];
+    const gp = getActiveGamepad();
     if (!gp?.vibrationActuator) return;
 
     const weak = Math.min(0.4 + progress * 1.0, 1.0);


### PR DESCRIPTION
## Summary

- Adds `gamepadconnected` / `gamepaddisconnected` listeners so Maida tracks the currently active gamepad instead of hardcoding `navigator.getGamepads()[0]`
- Centralizes gamepad lookup in a new `src/services/gamepad.js` module; `useGameInput`, `useGamepadScroll`, and `haptics` all call `getActiveGamepad()` so input polling, analog scroll, and vibration stay on the same pad
- Removes the need to press Ctrl+R after unplug + replug on Windows

## Background

On Windows HID, a disconnect does not always fire a clean `gamepaddisconnected` event. The slot at index 0 is left as a ghost entry and a reconnected pad gets assigned to index 1, invisible to Maida until the page is reloaded. This PR fixes that at the root by:

- Listening for connect events and switching the active index to the freshly-connected pad
- Rescanning on disconnect so another still-connected pad is picked up automatically
- Running an initial scan on first access so pads already connected at app launch are picked up even if their `gamepadconnected` event fired before listeners were installed
- Handling the ghost-slot case in `getActiveGamepad()` — if the stored index returns null, rescan and fall through to any live pad

## Architecture note

The lookup lives in `src/services/` rather than being lifted through hooks because `haptics.js` is a service and should not import from `src/hooks/`. Services-level state with lazy init keeps the dependency graph hooks → services and matches the existing singleton pattern in `bridge.js` / `persistence.js`.

## Red line impact

- 7.3 (Space blocked on buttons) unchanged
- 7.4 (tap / anchor thresholds) unchanged
- 7.8 (`useGamepadScroll` singleton) mount structure unchanged, only internal polling target switched
- 7.10, 7.11 not applicable

## Test plan

- [ ] `pnpm run tauri dev`
- [ ] Plug gamepad, verify D-pad navigation in Kamae view
- [ ] Unplug gamepad mid-session — confirm input stops (expected)
- [ ] Replug gamepad without pressing Ctrl+R — confirm input resumes immediately
- [ ] Repeat unplug / replug 3+ times, no reload needed any cycle
- [ ] Haptic feedback still fires on TRY long-press anchor (3s hold)
- [ ] R-stick scroll still works on legal page and Rin view
- [ ] Launching Maida with gamepad already connected: D-pad works immediately (initial scan path)
- [ ] Launching Maida without gamepad, plugging after launch: D-pad works immediately (event path)
- [ ] DevTools console verification: `gamepadconnected` / `gamepaddisconnected` events fire as expected during unplug / replug

## Files

- `src/services/gamepad.js` (new, 115 lines)
- `src/hooks/useGameInput.js` (polling target switch)
- `src/hooks/useGamepadScroll.js` (polling target switch)
- `src/services/haptics.js` (polling target switch)